### PR TITLE
Switches to multilingual Elevenlabs

### DIFF
--- a/app/src/tts-plugins/elevenlabs.tsx
+++ b/app/src/tts-plugins/elevenlabs.tsx
@@ -201,12 +201,14 @@ export default class ElevenLabsPlugin extends TTSPlugin<ElevenLabsPluginOptions>
         }
 
         const url = this.endpoint + '/v1/text-to-speech/' + voice.id;
+        const model_id = 'eleven_multilingual_v2';
 
         const response = await fetch(url, {
             headers: this.createHeaders(),
             method: 'POST',
             body: JSON.stringify({
                 text,
+                model_id,
             }),
         });
 


### PR DESCRIPTION
Since there's no setting available that defines a model for Elevenlabs, this commit switches the default model to eleven_multilingual_v2,
at the time of this writing the latest available text-to-speech model.
